### PR TITLE
Feat: Add Localization Support to ScreenshotApp

### DIFF
--- a/lib/src/screenshot_app.dart
+++ b/lib/src/screenshot_app.dart
@@ -9,6 +9,9 @@ class ScreenshotApp extends StatelessWidget {
     this.theme,
     required this.device,
     this.frameColors,
+    this.localizationsDelegates,
+    this.supportedLocales,
+    this.locale,
     required this.child,
   });
 
@@ -18,6 +21,15 @@ class ScreenshotApp extends StatelessWidget {
   /// The device whose resolution and pixel ratio will be simulated,
   /// and whose frame will be drawn around the [child].
   final ScreenshotDevice device;
+
+  /// The localization delegates that will be passed to [MaterialApp].
+  final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
+
+  /// The supported locales that will be passed to [MaterialApp].
+  final Iterable<Locale>? supportedLocales;
+
+  /// The locale that will be passed to [MaterialApp].
+  final Locale? locale;
 
   /// The colors of the device frame.
   final ScreenshotFrameColors? frameColors;
@@ -45,6 +57,9 @@ class ScreenshotApp extends StatelessWidget {
                   theme: theme,
                   themeAnimationDuration: Duration.zero,
                   debugShowCheckedModeBanner: false,
+                  localizationsDelegates: localizationsDelegates,
+                  supportedLocales: supportedLocales ?? const [Locale('en', 'US')],
+                  locale: locale,
                   home: device.frameBuilder(
                     device: device,
                     frameColors: frameColors,

--- a/lib/src/screenshot_app.dart
+++ b/lib/src/screenshot_app.dart
@@ -58,7 +58,8 @@ class ScreenshotApp extends StatelessWidget {
                   themeAnimationDuration: Duration.zero,
                   debugShowCheckedModeBanner: false,
                   localizationsDelegates: localizationsDelegates,
-                  supportedLocales: supportedLocales ?? const [Locale('en', 'US')],
+                  supportedLocales:
+                      supportedLocales ?? const [Locale('en', 'US')],
                   locale: locale,
                   home: device.frameBuilder(
                     device: device,


### PR DESCRIPTION
This change enables testing screenshots with different localizations.

## Changes
- Added `localizationsDelegates` property to support custom localizations
- Added `supportedLocales` property to specify supported locales
- Added `locale` property to force a specific locale for testing

## Testing
- [x] Tested with default locale
- [x] Tested with custom localizations
- [x] Verified with different locales (en_US, es_ES, ja_JP) in a sample app
- [x] Verified existing tests pass